### PR TITLE
Fixed documentation for sound_methods:stop

### DIFF
--- a/lua/starfall/libs_sh/sounds.lua
+++ b/lua/starfall/libs_sh/sounds.lua
@@ -74,7 +74,7 @@ function sound_methods:play ()
 end
 
 --- Stops the sound from being played.
--- @param fade Time in seconds to fade out, if nil or 0 the sound stops instantly.
+-- @param dt Time in seconds to fade out, if nil or 0 the sound stops instantly.
 function sound_methods:stop ( dt )
 	if not SF.Permissions.check( SF.instance.player, unwrap( self ), "sound.modify" ) then SF.throw( "Insufficient permissions", 2 ) end
 	if dt then


### PR DESCRIPTION
Originally showed up as `sound_methods:stop (dt, fade)` but should show `sound_methods:stop (dt)`
